### PR TITLE
Introducing phpspec for test coverage.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .idea
+/bin
+/vendor

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,12 @@
     "require": {
         "php": ">=5.3.2"
     },
+    "require-dev": {
+        "phpspec/phpspec": "~2.0"
+    },
+    "config": {
+        "bin-dir": "bin"
+    },
     "autoload": {
         "psr-0": {
             "SimpleUPS\\": "src/"

--- a/spec/SimpleUPS/AddressValidate/ResponseSpec.php
+++ b/spec/SimpleUPS/AddressValidate/ResponseSpec.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace spec\SimpleUPS\AddressValidate;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use SimpleUPS\AddressValidate\Address;
+
+class ResponseSpec extends ObjectBehavior
+{
+    function let(Address $address)
+    {
+        $this->beConstructedWith($address);
+    }
+
+    function it_populates_valid_response_from_xml()
+    {
+        $xml = new \SimpleXMLElement(file_get_contents(__DIR__.'/fixtures/AddressValidateResponse-Valid.xml'));
+
+        $this->isAddressValid()->shouldReturn(null);
+        $this->getCorrectedAddress()->shouldReturn(null);
+
+        $this->fromXml($xml);
+
+        $this->isAddressValid()->shouldReturn(true);
+        $this->getCorrectedAddress()->shouldReturnAnInstanceOf('SimpleUPS\AddressValidate\Address');
+    }
+}

--- a/spec/SimpleUPS/AddressValidate/fixtures/AddressValidateResponse-Valid.xml
+++ b/spec/SimpleUPS/AddressValidate/fixtures/AddressValidateResponse-Valid.xml
@@ -1,0 +1,15 @@
+<?xml version='1.0' standalone='yes'?>
+<Response>
+    <AddressKeyFormat>
+        <AddressClassification>
+            <Code>123</Code>
+        </AddressClassification>
+        <AddressLine>1234 Broadway</AddressLine>
+        <PoliticalDivision2>San Diego</PoliticalDivision2>
+        <PoliticalDivision1>CA</PoliticalDivision1>
+        <PostcodePrimaryLow>12345</PostcodePrimaryLow>
+        <PostcodeExtendedLow>1234</PostcodeExtendedLow>
+        <CountryCode>US</CountryCode>
+    </AddressKeyFormat>
+    <ValidAddressIndicator />
+</Response>


### PR DESCRIPTION
This is a baby-step to introduce test coverage. [phpSpec](http://phpspec.net) is an up-and-coming testing methodology with rapid growth of adoption over phpUnit.

If this approach is acceptable I would be happy to add more such tests, including realistic fixtures based on real UPS api responses.
